### PR TITLE
一些防呆设计，增加对苹果M系列芯片支持

### DIFF
--- a/code/chapter-8/01_classification/train_main.py
+++ b/code/chapter-8/01_classification/train_main.py
@@ -28,10 +28,10 @@ def get_args_parser(add_help=True):
 
     parser = argparse.ArgumentParser(description="PyTorch Classification Training", add_help=add_help)
 
-    parser.add_argument("--data-path", default=r"G:\deep_learning_data\chest_xray", type=str, help="dataset path")
+    parser.add_argument("--data-path", required = True,  type=str, help="dataset path, like G:\deep_learning_data\chest_xray/train")
     parser.add_argument("--model", default="convnext-tiny", type=str,
                         help="model name; resnet50/convnext/convnext-tiny")
-    parser.add_argument("--device", default="cuda", type=str, help="device (Use cuda or cpu Default: cuda)")
+    parser.add_argument("--device", default="cpu", type=str, help="device (Use cuda or cpu Default: cuda)")
     parser.add_argument(
         "-b", "--batch-size", default=8, type=int, help="images per gpu, the total batch size is $NGPU x batch_size"
     )

--- a/code/chapter-8/01_classification/train_main.py
+++ b/code/chapter-8/01_classification/train_main.py
@@ -216,5 +216,7 @@ classes = ["NORMAL", "PNEUMONIA"]
 if __name__ == "__main__":
     args = get_args_parser().parse_args()
     utils.setup_seed(args.random_seed)
-    args.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device_choices = ["cuda", "mps", "cpu"]
+    device = torch.device(args.device) if args.device in device_choices else torch.device("cpu")
+    args.device = device
     main(args)


### PR DESCRIPTION
感谢大佬分享，菜鸟最近正在研读


# 防呆设计
琢磨第8章的这段代码时发现几个默认设置很容易报错，略作修改，很小的改动，希望让本难以debug的同学们轻松一些
修改了--data-path为必须使用的参数,取消其默认设置,提示用户设置为自己的dataset路径
修改了--model默认参数为cpu,以免无gpu报错

# 增加对苹果M系列芯片支持
虽然只有一小撮人用MacBook学习pytorch，但也应该得到应有的支持😢